### PR TITLE
GetDisplay function, remove DPI awareness

### DIFF
--- a/scrap-sys/scrap-sys.h
+++ b/scrap-sys/scrap-sys.h
@@ -19,6 +19,8 @@ typedef struct {
 
 DisplayOrErr display_primary();
 
+DisplayOrErr get_display(int index);
+
 void display_free(struct Display* display);
 
 size_t display_width(struct Display* display);

--- a/scrap-sys/src/lib.rs
+++ b/scrap-sys/src/lib.rs
@@ -59,6 +59,25 @@ pub unsafe extern "C" fn display_primary() -> DisplayOrErr {
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn get_display(index: libc::c_int) -> DisplayOrErr {
+    let mut display = DisplayOrErr { display: std::ptr::null_mut(), err: std::ptr::null_mut() };
+    match scrap::Display::all() {
+        Ok(displays) => {
+            if index as usize < displays.len() {
+                display.display = Box::into_raw(Box::new(displays.into_iter().nth(index as usize).unwrap()))
+            }
+            else {
+                display.err = std::ffi::CString::new("No display found in this index").unwrap().into_raw();
+            }
+        }
+        Err(err) => {
+            display.err = std::ffi::CString::new(err.to_string()).unwrap().into_raw();
+        }
+    };
+    display
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn display_free(d: *mut scrap::Display) {
     Box::from_raw(d);
 }

--- a/scrap-sys/src/lib.rs
+++ b/scrap-sys/src/lib.rs
@@ -63,7 +63,7 @@ pub unsafe extern "C" fn get_display(index: libc::c_int) -> DisplayOrErr {
     let mut display = DisplayOrErr { display: std::ptr::null_mut(), err: std::ptr::null_mut() };
     match scrap::Display::all() {
         Ok(displays) => {
-            if index as usize < displays.len() {
+            if (index as usize) < displays.len() {
                 display.display = Box::into_raw(Box::new(displays.into_iter().nth(index as usize).unwrap()))
             }
             else {

--- a/scrap.go
+++ b/scrap.go
@@ -19,16 +19,9 @@ package scrap
 #include <stddef.h>
 #include <scrap-sys.h>
 
-#ifdef _WIN32
-	#include <Windows.h>
-	int set_dpi_aware() {
-		return SetProcessDPIAware();
-	}
-#else
-	int set_dpi_aware() {
-		return 1;
-	}
-#endif
+int set_dpi_aware() {
+	return 1;
+}
 
 struct Display* display_list_at(struct Display** list, int index) {
 	return list[index];
@@ -104,6 +97,16 @@ func (d *Display) setOwned(owned bool) {
 // PrimaryDisplay returns the primary display of the system or an error.
 func PrimaryDisplay() (*Display, error) {
 	d := C.display_primary()
+	if d.err != nil {
+		return nil, fromCgoErr(d.err)
+	}
+	return newDisplay(d.display), nil
+}
+
+// GetDisplay returns a display on the specified index
+func GetDisplay(index int) (*Display, error) {
+	i := C.int(index)
+	d := C.get_display(i)
 	if d.err != nil {
 		return nil, fromCgoErr(d.err)
 	}


### PR DESCRIPTION
GetDisplay loads all the displays and returns the one in the specified index.
An error is returned if the display loading failed or if the index is out of bounds.
This was implemented because the GetDisplays function doesn't work (at least on my system). @cretz I sent you an email with further details.

DPI awareness was turned off in order to support 64-bit systems. The SetProcessDPIAware function is deprecated and removed it seems from the latest Windows 10 builds, so disabling the feature entirely makes it possible to compile on the latest 64-bit Windows 10.